### PR TITLE
Magento 2.3.x compatible cloudinary:upload:all command

### DIFF
--- a/Model/ImageRepository.php
+++ b/Model/ImageRepository.php
@@ -61,7 +61,10 @@ class ImageRepository
     private function getRecursiveIterator($directory)
     {
         return new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($directory),
+            new \RecursiveDirectoryIterator(
+                $directory,
+                \FilesystemIterator::SKIP_DOTS
+            ),
             \RecursiveIteratorIterator::SELF_FIRST
         );
     }


### PR DESCRIPTION
This relates to issue #26 

Use the SKIP_DOTS flag to prevent the recursive image search trying to check "media/.." which causes Magento >= 2.3.0 to throw an exception.