### PR TITLE
CLOUDINARY-204

### DIFF
--- a/Controller/Adminhtml/Ajax/RetrieveImage.php
+++ b/Controller/Adminhtml/Ajax/RetrieveImage.php
@@ -12,7 +12,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\HTTP\Adapter\Curl;
 use Magento\Framework\Image\AdapterFactory as ImageAdapterFactory;
 use Magento\Framework\UrlInterface;
-use Magento\Framework\Validator\ValidatorInterface;
+use Magento\Framework\Validator\AllowedProtocols;
 use Magento\MediaStorage\Model\File\Validator\NotProtectedExtension;
 use Magento\MediaStorage\Model\ResourceModel\File\Storage\File as FileUtility;
 use Magento\Store\Model\StoreManagerInterface;
@@ -59,9 +59,9 @@ class RetrieveImage extends \Magento\Backend\App\Action
     protected $fileProcessor;
 
     /**
-     * URI validator
+     * AllowedProtocols validator
      *
-     * @var ValidatorInterface
+     * @var AllowedProtocols
      */
     private $protocolValidator;
 
@@ -85,7 +85,7 @@ class RetrieveImage extends \Magento\Backend\App\Action
      * @param  Curl                  $curl
      * @param  FileUtility           $fileUtility
      * @param  FileProcessor         $fileProcessor
-     * @param  ValidatorInterface    $protocolValidator
+     * @param  AllowedProtocols      $protocolValidator
      * @param  NotProtectedExtension $extensionValidator
      * @param  StoreManagerInterface $storeManager
      */
@@ -98,7 +98,7 @@ class RetrieveImage extends \Magento\Backend\App\Action
         Curl $curl,
         FileUtility $fileUtility,
         FileProcessor $fileProcessor,
-        ValidatorInterface $protocolValidator,
+        AllowedProtocols $protocolValidator,
         NotProtectedExtension $extensionValidator,
         StoreManagerInterface $storeManager
     ) {

--- a/Controller/Adminhtml/Cms/Wysiwyg/Images/Upload.php
+++ b/Controller/Adminhtml/Cms/Wysiwyg/Images/Upload.php
@@ -12,7 +12,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\HTTP\Adapter\Curl;
 use Magento\Framework\Image\AdapterFactory;
 use Magento\Framework\Registry;
-use Magento\Framework\Validator\ValidatorInterface;
+use Magento\Framework\Validator\AllowedProtocols;
 use Magento\MediaStorage\Model\File\Validator\NotProtectedExtension;
 use Magento\MediaStorage\Model\ResourceModel\File\Storage\File;
 
@@ -58,9 +58,9 @@ class Upload extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\Upload
     protected $fileUtility;
 
     /**
-     * URI validator
+     * AllowedProtocols validator
      *
-     * @var ValidatorInterface
+     * @var AllowedProtocols
      */
     private $protocolValidator;
 
@@ -81,7 +81,7 @@ class Upload extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\Upload
      * @param  AdapterFactory        $imageAdapterFactory
      * @param  Curl                  $curl
      * @param  File                  $fileUtility
-     * @param  ValidatorInterface    $protocolValidator
+     * @param  AllowedProtocols      $protocolValidator
      * @param  NotProtectedExtension $extensionValidator
      */
     public function __construct(
@@ -95,7 +95,7 @@ class Upload extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\Upload
         AdapterFactory $imageAdapterFactory,
         Curl $curl,
         File $fileUtility,
-        ValidatorInterface $protocolValidator,
+        AllowedProtocols $protocolValidator,
         NotProtectedExtension $extensionValidator
     ) {
         parent::__construct($context, $coreRegistry, $resultJsonFactory, $directoryResolver);

--- a/Model/BatchDownloader.php
+++ b/Model/BatchDownloader.php
@@ -15,7 +15,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\File\Uploader;
 use Magento\Framework\Filesystem;
 use Magento\Framework\HTTP\Adapter\Curl;
-use Magento\Framework\Validator\ValidatorInterface;
+use Magento\Framework\Validator\AllowedProtocols;
 use Magento\MediaStorage\Model\File\Validator\NotProtectedExtension;
 use Magento\MediaStorage\Model\ResourceModel\File\Storage\File as FileUtility;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -70,7 +70,7 @@ class BatchDownloader
     private $_fileUtility;
 
     /**
-     * @var ValidatorInterface
+     * @var AllowedProtocols
      */
     private $_protocolValidator;
 
@@ -115,7 +115,7 @@ class BatchDownloader
      * @param  Curl                                 $curl
      * @param  Filesystem                           $fileSystem
      * @param  FileUtility                          $fileUtility
-     * @param  ValidatorInterface                   $protocolValidator
+     * @param  AllowedProtocols                     $protocolValidator
      * @param  NotProtectedExtension                $extensionValidator
      * @param  SynchronizationCheck                 $synchronizationChecker
      * @param  SynchroniseAssetsRepositoryInterface $synchronisationRepository
@@ -129,7 +129,7 @@ class BatchDownloader
         Curl $curl,
         Filesystem $fileSystem,
         FileUtility $fileUtility,
-        ValidatorInterface $protocolValidator,
+        AllowedProtocols $protocolValidator,
         NotProtectedExtension $extensionValidator,
         SynchronizationCheck $synchronizationChecker,
         SynchroniseAssetsRepositoryInterface $synchronisationRepository

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -199,7 +199,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getUserPlatform()
     {
-        return sprintf(self::USER_PLATFORM_TEMPLATE, '1.9.8', '2.0.0');
+        return sprintf(self::USER_PLATFORM_TEMPLATE, '1.9.9', '2.0.0');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cloudinary/cloudinary-magento2",
     "description": "Cloudinary Magento 2 Integration.",
     "type": "magento2-module",
-    "version": "1.9.8",
+    "version": "1.9.9",
     "license": "MIT",
     "require": {
         "cloudinary/cloudinary_php": "*"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Cloudinary_Cloudinary" setup_version="1.9.8">
+  <module name="Cloudinary_Cloudinary" setup_version="1.9.9">
       <sequence>
           <module name="Magento_ProductVideo"/>
       </sequence>

--- a/marketplace.composer.json
+++ b/marketplace.composer.json
@@ -1,24 +1,18 @@
 {
-  "name": "cloudinary/cloudinary",
-  "type": "magento2-module",
-  "version": "1.9.8",
-  "description": "Cloudinary Magento 2 Integration.",
-  "license": "MIT",
-  "require": {
-    "cloudinary/cloudinary_php": "*"
-  },
-  "autoload": {
-    "files": [
-      "registration.php"
-    ],
-    "psr-4": {
-      "Cloudinary\\Cloudinary\\": ""
+    "name": "cloudinary/cloudinary",
+    "description": "Cloudinary Magento 2 Integration.",
+    "type": "magento2-module",
+    "version": "1.9.9",
+    "license": "MIT",
+    "require": {
+        "cloudinary/cloudinary_php": "*"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Cloudinary\\Cloudinary\\": ""
+        }
     }
-  },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://repo.magento.com/"
-    }
-  ]
 }


### PR DESCRIPTION
* Fixed Magento 2.1 error (GH issue #39): "...Fatal error: Uncaught Error: Cannot instantiate interface Magento\Framework\Validator\ValidatorInterface in..." by replacing Magento\Framework\Validator\ValidatorInterface with Magento\Framework\Validator\AllowedProtocols.