### PR TITLE
CLOUDINARY-224

### DIFF
--- a/Controller/Adminhtml/Ajax/RetrieveImage.php
+++ b/Controller/Adminhtml/Ajax/RetrieveImage.php
@@ -215,7 +215,7 @@ class RetrieveImage extends \Magento\Backend\App\Action
                 $localTmpFileName = DIRECTORY_SEPARATOR . $localFileName;
                 break;
             default:
-                $localTmpFileName = Uploader::getDispersionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
+                $localTmpFileName = Uploader::getDispretionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
                 break;
         }
         return $localTmpFileName;

--- a/Model/Api/ProductGalleryManagement.php
+++ b/Model/Api/ProductGalleryManagement.php
@@ -421,7 +421,7 @@ class ProductGalleryManagement implements \Cloudinary\Cloudinary\Api\ProductGall
     private function getLocalTmpFileName($remoteFileUrl)
     {
         $localFileName = Uploader::getCorrectFileName(basename($remoteFileUrl));
-        return Uploader::getDispersionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
+        return Uploader::getDispretionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
     }
 
     /**


### PR DESCRIPTION
* Replaced getDispersionPath() with getDispretionPath()… in order to support older Magento versions & avoid the `Uncaught Error: Call to undefined method Magento\Framework\File\Uploader::getDispersionPath()` error.