### PR TITLE
CLOUDINARY-224: replaced getDispersionPath() with getDispretionPath()…

### DIFF
--- a/Controller/Adminhtml/Ajax/RetrieveImage.php
+++ b/Controller/Adminhtml/Ajax/RetrieveImage.php
@@ -215,7 +215,7 @@ class RetrieveImage extends \Magento\Backend\App\Action
                 $localTmpFileName = DIRECTORY_SEPARATOR . $localFileName;
                 break;
             default:
-                $localTmpFileName = Uploader::getDispersionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
+                $localTmpFileName = Uploader::getDispretionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
                 break;
         }
         return $localTmpFileName;

--- a/Model/Api/ProductGalleryManagement.php
+++ b/Model/Api/ProductGalleryManagement.php
@@ -421,7 +421,7 @@ class ProductGalleryManagement implements \Cloudinary\Cloudinary\Api\ProductGall
     private function getLocalTmpFileName($remoteFileUrl)
     {
         $localFileName = Uploader::getCorrectFileName(basename($remoteFileUrl));
-        return Uploader::getDispersionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
+        return Uploader::getDispretionPath($localFileName) . DIRECTORY_SEPARATOR . $localFileName;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cloudinary/cloudinary-magento2",
     "description": "Cloudinary Magento 2 Integration.",
     "type": "magento2-module",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "license": "MIT",
     "require": {
         "cloudinary/cloudinary_php": "*"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Cloudinary_Cloudinary" setup_version="1.10.3">
+  <module name="Cloudinary_Cloudinary" setup_version="1.10.4">
       <sequence>
           <module name="Magento_ProductVideo"/>
       </sequence>

--- a/marketplace.composer.json
+++ b/marketplace.composer.json
@@ -2,7 +2,7 @@
     "name": "cloudinary/cloudinary",
     "description": "Cloudinary Magento 2 Integration.",
     "type": "magento2-module",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "license": "MIT",
     "require": {
         "cloudinary/cloudinary_php": "*"


### PR DESCRIPTION
* Replaced getDispersionPath() with getDispretionPath()… in order to support older Magento versions & avoid the `Uncaught Error: Call to undefined method Magento\Framework\File\Uploader::getDispersionPath()` error.