### PR TITLE
Fix version dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.14.4",
     "license": "MIT",
     "require": {
-        "cloudinary/cloudinary_php": "*"
+        "cloudinary/cloudinary_php": "^1.2"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Cloudinary PHP SDK v2 brought some breaking changes not (yet) compatible with this module. This quick-fix constraint to use the v1 for backwards compatibility.