### PR TITLE
Fix `Fallback to JQueryUI Compat activated`.

### DIFF
--- a/view/frontend/web/js/load-player.js
+++ b/view/frontend/web/js/load-player.js
@@ -4,12 +4,15 @@
  */
 
 /**
- @version  0.0.1
+ @version  0.0.2
  @requires jQuery & jQuery UI
  */
 
 define(
-    ['jquery', 'jquery/ui'],
+     [
+        'jquery',
+        'jquery-ui-modules/widget'
+    ],
     function ($) {
         'use strict';
 


### PR DESCRIPTION
This short PR fixes:

```Fallback to JQueryUI Compat activated. Your store is missing a dependency for a jQueryUI widget. Identifying and addressing the dependency will drastically improve the performance of your site. Compat.js```

`jquery/ui` is deprecated since Magento 2.3 and has been split into dedicated modules to improve performance.
