### PR TITLE
add: GraphQL support for query Cld images

### DIFF
--- a/Model/GraphQLResolver/ProductAttributeCldResolver.php
+++ b/Model/GraphQLResolver/ProductAttributeCldResolver.php
@@ -1,0 +1,42 @@
+<?php
+    declare(strict_types=1);
+    namespace Cloudinary\Cloudinary\Model\GraphQLResolver;
+
+    use Magento\Framework\GraphQl\Config\Element\Field;
+    use Magento\Framework\GraphQl\Query\ResolverInterface;
+    use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+    use Cloudinary\Cloudinary\Model\Api\ProductGalleryManagement;
+    use Magento\Framework\GraphQl\Type\Definition\ObjectType;
+
+    /**
+     * Class ProductAttributeCldResolver
+     **/
+    class ProductAttributeCldResolver implements ResolverInterface
+    {
+        /**
+         * @var ProductGalleryManagement
+         */
+        private $productGalleryManagement;
+
+        /**
+         * ProductAttributeCldResolver constructor.
+         * @param ProductGalleryManagement $productGalleryManagement
+         */
+        public function __construct(
+            ProductGalleryManagement $productGalleryManagement
+        ) {
+            $this->productGalleryManagement = $productGalleryManagement;
+        }
+
+        /**
+         * @inheritdoc
+         */
+        public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+        {
+            $productId = $value['sku'];
+            $productMediaStr = $this->productGalleryManagement->getProductMedia($productId);
+            $jsonDecoder = new \Magento\Framework\Serialize\Serializer\Json();
+            $productMedia = $jsonDecoder->unserialize($productMediaStr);
+            return $productMedia['data'];
+        }
+    }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,12 @@
+type CloudinaryData {
+    image: String
+    small_image: String
+    thumbnail: String
+    media_gallery: [String]
+}
+
+interface ProductInterface {
+    cld_data: CloudinaryData
+        @resolver(class: "\\Cloudinary\\Cloudinary\\Model\\GraphQLResolver\\ProductAttributeCldResolver")
+        @doc(description: "Cloudinary urls generated for product images")
+}


### PR DESCRIPTION
Changes:
1. Extended ProductAttribute GraphQL layer of Magento to support Cloudinary.
2. Return the query with image datas based on the current functionalities